### PR TITLE
Fix item wheel windows not being properly clear.

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2367,6 +2367,7 @@ static void FreeKeyItemWheelGfx(s16 *data) {
         if (tIconWindow[i] == WINDOW_NONE)
             continue;
         FillWindowPixelBuffer(tIconWindow[i], 0);
+        ClearWindowTilemap(tIconWindow[i]);
         CopyWindowToVram(tIconWindow[i], COPYWIN_GFX);
         RemoveWindow(tIconWindow[i]);
     }


### PR DESCRIPTION
## Description
After the key item wheel was removed, the blocks of the bg remained with certain ids instead of being properly clear. This is how it was before, note that Tile # is 1184
![image](https://github.com/aarant/pokeemerald/assets/18596778/a97cf14a-aecd-4955-a3d0-418c3c0614c6)

This is how it is now, Tile # properly cleared to 1024
![image](https://github.com/aarant/pokeemerald/assets/18596778/bbd1c818-f3be-4f90-89e8-d28d5e493fec)

Note that this bug doesn't affect vanilla emerald per se, since those tiles seem to be clear but they might affect projects that get use of those tiles in certain situations.
I had those blocks used by my start menu, even when vanilla doesn't, so the bug looked like this:
![image](https://github.com/aarant/pokeemerald/assets/18596778/5be4f76d-9b65-437a-917b-0ac30d41ff61)

Even if this doesn't solve a bug in vanilla, we must properly free our resources in cases like this.

## **Discord contact info**
671gz