### PR TITLE
Close Key Item Wheel with SELECT

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2412,7 +2412,7 @@ static void Task_KeyItemWheel(u8 taskId) {
     }
     case 1: // process input
     {
-        if (JOY_NEW(B_BUTTON)) {
+        if (JOY_NEW(B_BUTTON) || JOY_NEW(SELECT_BUTTON)) {
             PlaySE(SE_SELECT);
             tState = 3; // destroy and unfreeze
             break;


### PR DESCRIPTION
## Description
Suggested by an user in my Discord.
This doesn't remove closing it with the B button, just adds select as an alternative, since it's the used key to open it.

## **Discord contact info**
671gz