### PR TITLE
Properly clear windows after closing the key item wheel

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2368,7 +2368,7 @@ static void FreeKeyItemWheelGfx(s16 *data) {
             continue;
         FillWindowPixelBuffer(tIconWindow[i], 0);
         ClearWindowTilemap(tIconWindow[i]);
-        CopyWindowToVram(tIconWindow[i], COPYWIN_GFX);
+        CopyWindowToVram(tIconWindow[i], COPYWIN_MAP);
         RemoveWindow(tIconWindow[i]);
     }
     SetHBlankCallback(NULL);


### PR DESCRIPTION
## Description
Turns out the key item wheel windows were getting properly clear.
Fixes #9.

## **Discord contact info**
671gz