### PR TITLE
Fix max length player name causing overflow+crash on whiteout.

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2593,7 +2593,7 @@ u32 BattleStringExpandPlaceholders(const u8 *src, u8 *dst)
                 #if (DECAP_ENABLED) && !(DECAP_NICKNAMES)
                 if (toCpy != text && *toCpy != CHAR_FIXED_CASE && !(*src & PLACEHOLDER_FIXED_MASK)) {
                     *text = CHAR_FIXED_CASE;
-                    StringCopyN(text+1, toCpy, PLAYER_NAME_LENGTH);
+                    StringCopyN(text+1, toCpy, PLAYER_NAME_LENGTH + 1);
                     toCpy = text;
                 }
                 #endif


### PR DESCRIPTION
## Description
This copies PLAYER_NAME_LENGTH+1 characters to dest buffer to include the last null terminator when Guillotine appends the fixed case char for player names.

Before
![7chars](https://github.com/aarant/pokeemerald/assets/39687914/621f2fd1-2c9c-41d6-ace1-50be82b41a63)

After
![fix7chars](https://github.com/aarant/pokeemerald/assets/39687914/14bef8c0-4451-4ef2-981e-889fdaed1622)

## **Discord contact info**
ultimate_bob