### PR TITLE
Fix Blinking Lights in Rustboro

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2399,9 +2399,10 @@ void UpdateLightSprite(struct Sprite *sprite) {
             if (GetSpritePaletteTagByPaletteNum(sprite->oam.paletteNum) == OBJ_EVENT_PAL_TAG_LIGHT_2)
                 LoadSpritePaletteInSlot(&sObjectEventSpritePalettes[FindObjectEventPaletteIndexByTag(OBJ_EVENT_PAL_TAG_LIGHT)], sprite->oam.paletteNum);
         } else if ((sprite->invisible = gTimeUpdateCounter & 1)) {
-            Weather_SetBlendCoeffs(12, 12);
-            if (GetSpritePaletteTagByPaletteNum(sprite->oam.paletteNum) == OBJ_EVENT_PAL_TAG_LIGHT)
-                LoadSpritePaletteInSlot(&sObjectEventSpritePalettes[FindObjectEventPaletteIndexByTag(OBJ_EVENT_PAL_TAG_LIGHT_2)], sprite->oam.paletteNum);
+            Weather_SetBlendCoeffs(7, 12); // As long as the second coefficient stays 12, shadows will not change
+            sprite->invisible = FALSE;
+            if (GetSpritePaletteTagByPaletteNum(sprite->oam.paletteNum) == OBJ_EVENT_PAL_TAG_LIGHT_2)
+                LoadSpritePaletteInSlot(&sObjectEventSpritePalettes[FindObjectEventPaletteIndexByTag(OBJ_EVENT_PAL_TAG_LIGHT)], sprite->oam.paletteNum);
         }
         break;
     case 1 ... 2:


### PR DESCRIPTION
This seems to fix the blinking lights issue in Rustboro City.

## Description
In the function UpdateLightSprite in event_object_movement.c, I changed a few lines to replicate how the light looks while the Player is moving (where it doesn't blink). I've done some testing and it seems to fix the blinking, and I haven't noticed any drawbacks so far.

## **Discord contact info**
My Discord is "nemo622" in the RHH Discord Server!