### PR TITLE
Fixed Braille Dig puzzle freezing Followers

### DIFF
--- a/src/braille_puzzles.c
+++ b/src/braille_puzzles.c
@@ -87,6 +87,7 @@ void DoBrailleDigEffect(void)
     DrawWholeMapView();
     PlaySE(SE_BANG);
     FlagSet(FLAG_SYS_BRAILLE_DIG);
+    UnfreezeObjectEvents();
     UnlockPlayerFieldControls();
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using dig for the braille puzzle in the Sealed Chamber freezes followers (and other overworld entities, but there are none present) until they're unfrozen by other means.

https://github.com/user-attachments/assets/96f311a0-d81f-4dda-9fbf-45c4b455236c

Adding a `UnfreezeObjectEvents();` to `DoBrailleDigEffect` fixes this.

https://github.com/user-attachments/assets/8f56be55-2c47-437a-8b2d-401d3705cd92



## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
hedara