### PR TITLE
Make .pal files depend on .pla files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,8 +271,10 @@ generated: $(AUTO_GEN_TARGETS)
 
 %.s:   ;
 %.png: ;
-%.pal: ;
 %.aif: ;
+# touch the .pal file to indicate to gbagfx to rebuild the .gbapal when the .pla is changed
+%.pal: %.pla
+	@touch $@
 
 %.1bpp:   %.png  ; $(GFX) $< $@
 %.4bpp:   %.png  ; $(GFX) $< $@

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ on separate lines to mark those colors as being light-blended, i.e:
 10
 ```
 
-You might have to `make mostlyclean` or change the `.pal` file to pick up the changes.
-
 ### `(guillotine)` Q: How can I keep my string(s) from being decapped?
 A: There are a number of ways to make a string "fixed case" so that it will not be decapitalized when displayed:
 


### PR DESCRIPTION
A pain point for users working with .pla files is that changing them doesn't cause their corresponding palettes' .gbapal files to be rebuilt. However, making the .gbapal files depend on the .pla files is clunky with how the target is written for .gbapal files. If you write an additional target to make .gbapal files depend on .pla files, changes to .pal files won't trigger a rebuild if they have a corresponding .pla file.

I've instead opted to make the .pal files depend on the .pla files and update the timestamp on the .pal files to cause `gbagfx` to rebuild them. Definitely open to alternative ways to write this dependency if anyone has a better idea.

## **Discord contact info**
ravepossum
