### PR TITLE
GetFirstLiveMon Nomenclature and Littleroot Followers

### DIFF
--- a/data/scripts/follower.inc
+++ b/data/scripts/follower.inc
@@ -10,12 +10,12 @@ gText_FollowerDefault::
 gText_WantsToFly::
 	.string "{STR_VAR_1} looks up at the\nsky restlessly.\pWould you like to use FLY?$"
 
-.macro playfirstmoncry
-callfunc ScrFunc_playfirstmoncry
+.macro playfirstfollowmoncry
+callfunc ScrFunc_playfirstfollowmoncry
 .endm
 
-.macro bufferlivemonnickname out:req
-callfunc ScrFunc_bufferlivemonnickname
+.macro bufferlivefollowmonnickname out:req
+callfunc ScrFunc_bufferlivefollowmonnickname
 .byte \out
 .endm
 
@@ -27,8 +27,8 @@ callfunc ScrFunc_emote
 
 EventScript_Follower::
 	lock
-	bufferlivemonnickname 0
-	playfirstmoncry
+	bufferlivefollowmonnickname 0
+	playfirstfollowmoncry
 	callfunc ScrFunc_getfolloweraction
 EventScript_FollowerEnd::
 	waitfieldeffect FLDEFF_EMOTE

--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -326,7 +326,7 @@
 // These accept vars, too: VAR_TEMP_1, etc
 #define OW_MON_ALLOWED_SPECIES (0)
 #define OW_MON_ALLOWED_MET_LVL (0)
-#define OW_MON_ALLOWED_MET_LOC (0)
+#define OW_MON_ALLOWED_MET_LOC (MAPSEC_COUNT)
 // Examples:
 // Yellow Pikachu:
 // #define OW_MON_ALLOWED_SPECIES (SPECIES_PIKACHU)
@@ -339,7 +339,7 @@
 // Species set in VAR_XXXX:
 // #define OW_MON_ALLOWED_SPECIES (VAR_XXXX)
 // #define OW_MON_ALLOWED_MET_LVL (0)
-// #define OW_MON_ALLOWED_MET_LOC (0)
+// #define OW_MON_ALLOWED_MET_LOC (MAPSEC_COUNT)
 
 #define SHADOW_SIZE_S   0
 #define SHADOW_SIZE_M   1

--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -130,7 +130,7 @@ void SetSpritePosToOffsetMapCoords(s16 *x, s16 *y, s16 dx, s16 dy);
 void ClearObjectEventMovement(struct ObjectEvent *objectEvent, struct Sprite *sprite);
 void ObjectEventClearHeldMovement(struct ObjectEvent *objectEvent);
 void ObjectEventClearHeldMovementIfActive(struct ObjectEvent *objectEvent);
-struct Pokemon * GetFirstLiveMon(void);
+struct Pokemon * GetFirstLiveFollowMon(void);
 void UpdateFollowingPokemon(void);
 void RemoveFollowingPokemon(void);
 struct ObjectEvent * GetFollowerObject(void);

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2213,7 +2213,7 @@ static bool8 ShouldDoSlideInAnim(void) {
     )
         return FALSE;
 
-    if (GetFirstLiveMon() != &gPlayerParty[gBattlerPartyIndexes[gActiveBattler]])
+    if (GetFirstLiveFollowMon() != &gPlayerParty[gBattlerPartyIndexes[gActiveBattler]])
         return FALSE;
 
     return TRUE;

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1946,7 +1946,7 @@ struct Pokemon *GetFirstLiveFollowMon(void) { // Return address of first conscio
         struct Pokemon *mon = &gPlayerParty[i];
         if ((OW_MON_ALLOWED_SPECIES && GetMonData(mon, MON_DATA_SPECIES_OR_EGG) != VarGet(OW_MON_ALLOWED_SPECIES))
             || (OW_MON_ALLOWED_MET_LVL && GetMonData(mon, MON_DATA_MET_LEVEL) != VarGet(OW_MON_ALLOWED_MET_LVL))
-            || (OW_MON_ALLOWED_MET_LOC && GetMonData(mon, MON_DATA_MET_LOCATION) != VarGet(OW_MON_ALLOWED_MET_LOC))
+            || (OW_MON_ALLOWED_MET_LOC != MAPSEC_COUNT && GetMonData(mon, MON_DATA_MET_LOCATION) != VarGet(OW_MON_ALLOWED_MET_LOC))
         ) {
             continue;
         }

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1940,7 +1940,7 @@ u8 CreateVirtualObject(u16 graphicsId, u8 virtualObjId, s16 x, s16 y, u8 elevati
     return spriteId;
 }
 
-struct Pokemon *GetFirstLiveMon(void) { // Return address of first conscious party mon or NULL
+struct Pokemon *GetFirstLiveFollowMon(void) { // Return address of first conscious party follow mon or NULL
     u32 i;
     for (i = 0; i < PARTY_SIZE; i++) {
         struct Pokemon *mon = &gPlayerParty[i];
@@ -2124,7 +2124,7 @@ static bool8 GetMonInfo(struct Pokemon * mon, u16 *species, u8 *form, u8 *shiny)
 
 // Retrieve graphic information about the following pokemon, if any
 static bool8 GetFollowerInfo(u16 *species, u8 *form, u8 *shiny) {
-    return GetMonInfo(GetFirstLiveMon(), species, form, shiny);
+    return GetMonInfo(GetFirstLiveFollowMon(), species, form, shiny);
 }
 
 void UpdateFollowingPokemon(void) { // Update following pokemon if any
@@ -2327,7 +2327,7 @@ bool8 ScrFunc_getfolloweraction(struct ScriptContext *ctx) // Essentially a big 
     u32 condCount = 0;
     u32 emotion;
     struct ObjectEvent *objEvent = GetFollowerObject();
-    struct Pokemon *mon = GetFirstLiveMon();
+    struct Pokemon *mon = GetFirstLiveFollowMon();
     u8 emotion_weight[FOLLOWER_EMOTION_LENGTH] = {
         [FOLLOWER_EMOTION_HAPPY] = 10,
         [FOLLOWER_EMOTION_NEUTRAL] = 15,
@@ -5874,7 +5874,7 @@ bool8 ScrFunc_GetDirectionToFace(struct ScriptContext *ctx) {
 bool8 ScrFunc_IsFollowerFieldMoveUser(struct ScriptContext *ctx) {
     u16 *var = GetVarPointer(ScriptReadHalfword(ctx));
     u16 userIndex = gFieldEffectArguments[0]; // field move user index
-    struct Pokemon *follower = GetFirstLiveMon();
+    struct Pokemon *follower = GetFirstLiveFollowMon();
     struct ObjectEvent *obj = GetFollowerObject();
     if (var == NULL)
         return FALSE;
@@ -7053,7 +7053,7 @@ static void ObjectEventSetPokeballGfx(struct ObjectEvent *objEvent) {
     #if OW_MON_POKEBALLS
     u32 ball = BALL_POKE;
     if (objEvent->localId == OBJ_EVENT_ID_FOLLOWER) {
-        struct Pokemon *mon = GetFirstLiveMon();
+        struct Pokemon *mon = GetFirstLiveFollowMon();
         if (mon)
             ball = ItemIdToBallId(GetMonData(mon, MON_DATA_POKEBALL));
     }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1625,11 +1625,11 @@ bool8 ScrCmd_bufferleadmonspeciesname(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrFunc_bufferlivemonnickname(struct ScriptContext *ctx)
+bool8 ScrFunc_bufferlivefollowmonnickname(struct ScriptContext *ctx)
 {
     u8 stringVarIndex = ScriptReadByte(ctx);
 
-    GetMonData(GetFirstLiveMon(), MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
+    GetMonData(GetFirstLiveFollowMon(), MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
     StringGet_Nickname(sScriptStringVars[stringVarIndex]);
     return FALSE;
 }
@@ -2093,9 +2093,9 @@ bool8 ScrCmd_playmoncry(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8   ScrFunc_playfirstmoncry(struct ScriptContext *ctx)
+bool8   ScrFunc_playfirstfollowmoncry(struct ScriptContext *ctx)
 {
-    u16 species = GetMonData(GetFirstLiveMon(), MON_DATA_SPECIES);
+    u16 species = GetMonData(GetFirstLiveFollowMon(), MON_DATA_SPECIES);
     PlayCry_Script(species, 0);
     return FALSE;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As an expansion developer, I was recommended that I PR this here as it's related to the follower functions, but happy redirect it back if you wish.

When using the `FOLLOWERS_ALLOWED_X` defines, the `GetFirstLiveMon` function (and others that rely on it) may result in a `NULL` value, even if a healthy non-egg is present in the party. While the current use case of these work as it is intended, the first commit in this PR updates the names of these functions to reflect this stipulation, in case users try using it elsewhere.

The second commit in this PR updates the default value of `OW_MON_ALLOWED_MET_LOC` to `MAPSEC_COUNT`, as there will be unintended behaviour when trying to restrict followers to those given in Littleroot Town as `MAPSEC_LITTLEROOT_TOWN` has a value of 0.

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
Contactable via this GitHub account or as HashtagMarky#4240 on Discord.
